### PR TITLE
Reorder homepage product cards, fold surveillance link into Smart Edge Devices

### DIFF
--- a/index.html
+++ b/index.html
@@ -89,39 +89,6 @@
                 <p class="text-xl text-gray-600">Innovative hardware solutions for modern businesses</p>
             </div>
             <div class="grid md:grid-cols-2 lg:grid-cols-3 gap-8">
-                <div class="bg-white rounded-lg shadow-md p-6 hover:shadow-lg transition-shadow">
-                    <i data-lucide="server" class="h-10 w-10 text-blue-600 mb-4"></i>
-                    <h3 class="text-xl font-semibold mb-3">AI Servers</h3>
-                    <p class="text-gray-600 mb-4">High-performance servers optimized for AI workloads and machine learning applications.</p>
-                    <ul class="text-sm text-gray-500 space-y-1">
-                        <li>• GPU acceleration support</li>
-                        <li>• Scalable architecture</li>
-                        <li>• Enterprise-grade reliability</li>
-                    </ul>
-                </div>
-                <div class="bg-white rounded-lg shadow-md p-6 hover:shadow-lg transition-shadow">
-                    <i data-lucide="smartphone" class="h-10 w-10 text-blue-600 mb-4"></i>
-                    <h3 class="text-xl font-semibold mb-3">Smart Edge Devices</h3>
-                    <p class="text-gray-600 mb-4">IoT-enabled devices that seamlessly integrate with your existing infrastructure.</p>
-                    <ul class="text-sm text-gray-500 space-y-1">
-                        <li>• Wireless connectivity</li>
-                        <li>• Real-time monitoring</li>
-                        <li>• Energy efficient</li>
-                    </ul>
-                </div>
-                <div class="bg-gradient-to-br from-green-50 to-blue-50 rounded-lg shadow-lg p-6 hover:shadow-xl transition-shadow border-2 border-green-300">
-                    <i data-lucide="camera" class="h-10 w-10 text-green-600 mb-4"></i>
-                    <h3 class="text-xl font-semibold mb-3 text-green-700">AI Surveillance Monitoring</h3>
-                    <p class="text-gray-700 mb-4">Industrial campus use-case: edge AI surveillance for 50-100 cameras with radar integration at vehicle entrances.</p>
-                    <ul class="text-sm text-gray-600 space-y-1 mb-4">
-                        <li>• RK3588, QCS8550, Jetson Orin hardware tiers</li>
-                        <li>• Radar fusion for factories & gated communities</li>
-                        <li>• Reference architecture, BOM & sizing guide</li>
-                    </ul>
-                    <a href="ai-surveillance-monitoring.html" class="inline-block bg-gradient-to-r from-green-600 to-blue-600 text-white px-6 py-2 rounded-lg font-semibold hover:from-green-700 hover:to-blue-700 transition-colors">
-                        View Use-Case
-                    </a>
-                </div>
                 <div class="bg-gradient-to-br from-blue-50 to-purple-50 rounded-lg shadow-lg p-6 hover:shadow-xl transition-shadow border-2 border-blue-300">
                     <i data-lucide="cpu" class="h-10 w-10 text-purple-600 mb-4"></i>
                     <h3 class="text-xl font-semibold mb-3 text-purple-700">AI Embedded SW Dev Platform</h3>
@@ -132,8 +99,31 @@
                         <li>• Framework Desktop for embedded testing</li>
                     </ul>
                     <a href="ai-desktop-products.html" class="inline-block bg-gradient-to-r from-blue-600 to-purple-600 text-white px-6 py-2 rounded-lg font-semibold hover:from-blue-700 hover:to-purple-700 transition-colors">
-                        View Platform Comparison
+                        View Platforms Comparison
                     </a>
+                </div>
+                <div class="bg-white rounded-lg shadow-md p-6 hover:shadow-lg transition-shadow">
+                    <i data-lucide="smartphone" class="h-10 w-10 text-blue-600 mb-4"></i>
+                    <h3 class="text-xl font-semibold mb-3">Smart Edge Devices</h3>
+                    <p class="text-gray-600 mb-4">IoT-enabled devices that seamlessly integrate with your existing infrastructure.</p>
+                    <ul class="text-sm text-gray-500 space-y-1 mb-4">
+                        <li>• Wireless connectivity</li>
+                        <li>• Real-time monitoring</li>
+                        <li>• Energy efficient</li>
+                    </ul>
+                    <a href="ai-surveillance-monitoring.html" class="inline-block bg-blue-600 text-white px-6 py-2 rounded-lg font-semibold hover:bg-blue-700 transition-colors">
+                        Edge Device Monitoring Use-Case
+                    </a>
+                </div>
+                <div class="bg-white rounded-lg shadow-md p-6 hover:shadow-lg transition-shadow">
+                    <i data-lucide="server" class="h-10 w-10 text-blue-600 mb-4"></i>
+                    <h3 class="text-xl font-semibold mb-3">AI Servers</h3>
+                    <p class="text-gray-600 mb-4">High-performance servers optimized for AI workloads and machine learning applications.</p>
+                    <ul class="text-sm text-gray-500 space-y-1">
+                        <li>• GPU acceleration support</li>
+                        <li>• Scalable architecture</li>
+                        <li>• Enterprise-grade reliability</li>
+                    </ul>
                 </div>
             </div>
         </div>
@@ -275,10 +265,9 @@
                 <div>
                     <h4 class="text-lg font-semibold mb-4">Products</h4>
                     <ul class="space-y-2 text-gray-400">
-                        <li><a href="#" class="hover:text-white transition-colors">AI Servers</a></li>
-                        <li><a href="#" class="hover:text-white transition-colors">Smart Edge Devices</a></li>
-                        <li><a href="ai-surveillance-monitoring.html" class="hover:text-white transition-colors text-blue-400">AI Surveillance Monitoring Use-Case</a></li>
                         <li><a href="ai-desktop-products.html" class="hover:text-white transition-colors text-blue-400">AI Embedded SW Dev Platform ⭐</a></li>
+                        <li><a href="ai-surveillance-monitoring.html" class="hover:text-white transition-colors text-blue-400">Smart Edge Devices: Monitoring Use-Case</a></li>
+                        <li><a href="#" class="hover:text-white transition-colors">AI Servers</a></li>
                     </ul>
                 </div>
                 <div>


### PR DESCRIPTION
## Summary
- Reordered the homepage Products grid to: AI Embedded SW Dev Platform, Smart Edge Devices, AI Servers.
- Removed the standalone "AI Surveillance Monitoring" card. The link to `ai-surveillance-monitoring.html` is now a CTA button ("Edge Device Monitoring Use-Case") inside the existing Smart Edge Devices card, alongside its original content.
- Renamed the AI Embedded SW Dev Platform CTA to "View Platforms Comparison" for consistency.
- Updated the footer Products list to match: AI Embedded SW Dev Platform, Smart Edge Devices (linking to the monitoring use-case), AI Servers.

## Test plan
- [x] Verified the diff only touches the Products section and footer Products list.
- [ ] Confirm CI build passes.
- [ ] Manually check the homepage renders 3 product cards in the new order with working links.

---
_Generated by [Claude Code](https://claude.ai/code/session_019wZPDR8m9xb56eeNppRbm7)_