### PR TITLE
Give Smart Edge Devices card the same border/gradient treatment as SW Dev card

### DIFF
--- a/index.html
+++ b/index.html
@@ -102,16 +102,16 @@
                         View Platforms Comparison
                     </a>
                 </div>
-                <div class="bg-white rounded-lg shadow-md p-6 hover:shadow-lg transition-shadow">
+                <div class="bg-gradient-to-br from-blue-50 to-cyan-50 rounded-lg shadow-lg p-6 hover:shadow-xl transition-shadow border-2 border-blue-300">
                     <i data-lucide="smartphone" class="h-10 w-10 text-blue-600 mb-4"></i>
-                    <h3 class="text-xl font-semibold mb-3">Smart Edge Devices</h3>
-                    <p class="text-gray-600 mb-4">IoT-enabled devices that seamlessly integrate with your existing infrastructure.</p>
-                    <ul class="text-sm text-gray-500 space-y-1 mb-4">
+                    <h3 class="text-xl font-semibold mb-3 text-blue-700">Smart Edge Devices</h3>
+                    <p class="text-gray-700 mb-4">IoT-enabled devices that seamlessly integrate with your existing infrastructure.</p>
+                    <ul class="text-sm text-gray-600 space-y-1 mb-4">
                         <li>• Wireless connectivity</li>
                         <li>• Real-time monitoring</li>
                         <li>• Energy efficient</li>
                     </ul>
-                    <a href="ai-surveillance-monitoring.html" class="inline-block bg-blue-600 text-white px-6 py-2 rounded-lg font-semibold hover:bg-blue-700 transition-colors">
+                    <a href="ai-surveillance-monitoring.html" class="inline-block bg-gradient-to-r from-blue-600 to-cyan-600 text-white px-6 py-2 rounded-lg font-semibold hover:from-blue-700 hover:to-cyan-700 transition-colors">
                         Edge Device Monitoring Use-Case
                     </a>
                 </div>


### PR DESCRIPTION
## Summary
- Smart Edge Devices now shares the same "featured card" visual treatment as AI Embedded SW Dev Platform: gradient background, `border-2 border-blue-300`, colored heading, gradient CTA button. Previously it had a plain white card despite carrying a CTA link, which looked inconsistent next to the SW Dev Platform card's colored border/gradient.
- Uses a blue→cyan theme (vs. SW Dev Platform's blue→purple) to stay visually distinct while matching the same structure.
- AI Servers is untouched — it has no CTA link, so it stays a plain white card.

## Test plan
- [x] Verified the diff only touches the Smart Edge Devices card's classes.
- [ ] Confirm CI build passes.
- [ ] Visually confirm both featured cards look uniform on the homepage.

---
_Generated by [Claude Code](https://claude.ai/code/session_019wZPDR8m9xb56eeNppRbm7)_